### PR TITLE
Small performance optimization

### DIFF
--- a/src/PozitronDev.Convert/ConvertTo.cs
+++ b/src/PozitronDev.Convert/ConvertTo.cs
@@ -11,7 +11,7 @@ namespace PozitronDev.Convert
     {
         private object input;
 
-        private bool isInputNullOrEmptyString => (input == null || input.ToString().Length == 0);
+        private bool isInputNullOrEmptyString;
 
         /// <summary>
         /// It requires object value upon which "To" clauses are built.
@@ -20,6 +20,7 @@ namespace PozitronDev.Convert
         public ConvertTo(object input)
         {
             this.input = input;
+            isInputNullOrEmptyString = (input == null || input.ToString().Length == 0);
         }
 
         /// <summary>

--- a/src/PozitronDev.Convert/ConvertTo.cs
+++ b/src/PozitronDev.Convert/ConvertTo.cs
@@ -11,7 +11,7 @@ namespace PozitronDev.Convert
     {
         private object input;
 
-        private bool isInputNullOrEmptyString => (input == null || input.ToString() == string.Empty);
+        private bool isInputNullOrEmptyString => (input == null || input.ToString().Length == 0);
 
         /// <summary>
         /// It requires object value upon which "To" clauses are built.


### PR DESCRIPTION
Comparing a string against `.Length == 0` is faster than ` == string.Empty`. See [CA1820](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1820) about that.